### PR TITLE
Don't HTTP-cache authenticated API requests

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -203,6 +203,8 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 			...options,
 			url,
 			headers: {
+				"Cache-Control": "no-cache",
+				"Pragma": "no-cache",
 				...options.headers,
 				"Authorization": `Bearer ${this.access_token}`
 			}


### PR DESCRIPTION
**Observed (self-host):** after a transient server misconfig, the plugin stays broken even once the server is fixed — only deleting Electron's cache recovers it. The failing `GET /api/sync/user` never appears in the origin access log.

**Root cause:** `authenticatedRequest` sends no cache-control. Obsidian's `requestUrl` uses Electron's network stack, which honors HTTP caching, so a once-cacheable response (e.g. an HTML `/login` page returned during the misconfig) is cached and then replayed indefinitely without contacting the server.

**Fix:** send `Cache-Control: no-cache` and `Pragma: no-cache` on authenticated requests so Electron always revalidates. An authenticated, per-user API response should never be cached anyway.

**Why the hosted product is unaffected:** healthy per-user responses are already fresh; this only prevents stale replay. Built clean (`bun run build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
