### PR TITLE
Self-hosted: opt-in automatic sync (draft / proposal)

### DIFF
--- a/@types/scrybble.ts
+++ b/@types/scrybble.ts
@@ -15,6 +15,11 @@ export interface ScrybbleSettings {
 	custom_host: Host;
 	sync_state: Record<string, number>;
 
+	auto_sync: boolean;
+	auto_sync_interval_minutes: number;
+	auto_sync_baselined: boolean;
+	auto_sync_seen: string[];
+
 	access_token?: string;
 	refresh_token?: string;
 

--- a/features/support/ObsidianWorld.ts
+++ b/features/support/ObsidianWorld.ts
@@ -36,7 +36,11 @@ export class ObsidianWorld extends World {
 				client_id: ""
 			},
 
-			self_hosted: false
+			self_hosted: false,
+			auto_sync: false,
+			auto_sync_interval_minutes: 15,
+			auto_sync_baselined: false,
+			auto_sync_seen: []
 		}, () => {
 			return Promise.resolve();
 		});

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import {App, Modal, Plugin, requestUrl, Setting, WorkspaceLeaf} from 'obsidian';
+import {App, Modal, Notice, Plugin, requestUrl, Setting, WorkspaceLeaf} from 'obsidian';
 import {
 	AuthenticateWithGumroadLicenseResponse,
 	DeviceCodeResponse,
@@ -83,6 +83,8 @@ class InputModal extends Modal {
 	}
 }
 
+const AUTO_SYNC_MAX_PER_TICK = 10;
+
 export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePersistentStorage {
 	// @ts-expect-error TS2564 -- onload acts as a constructor.
 	public settings: ScrybbleSettings;
@@ -90,6 +92,8 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 	public syncQueue: SyncQueue;
 	// @ts-expect-error TS2564 -- onload acts as a constructor.
 	public authentication: Authentication;
+
+	private autoSyncTimer: number | null = null;
 
 	get access_token(): string | null {
 		return this.settings.access_token ?? null;
@@ -453,6 +457,137 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 		await this.authentication.initializeAuth();
 		if (this.authentication.isAuthenticated()) {
 			await this.sync();
+			this.startAutoSync();
+		}
+	}
+
+	startAutoSync(): void {
+		this.stopAutoSync();
+		if (!this.settings.self_hosted || !this.settings.auto_sync || !this.authentication.isAuthenticated()) {
+			return;
+		}
+		const minutes = Math.max(1, this.settings.auto_sync_interval_minutes || 15);
+		this.autoSyncTimer = window.setInterval(() => {
+			void this.autoSyncScan();
+		}, minutes * 60_000);
+		this.registerInterval(this.autoSyncTimer);
+
+		// Snapshot the existing library right away the first time it's enabled, so the
+		// backlog is baselined immediately instead of after a full interval.
+		if (!this.settings.auto_sync_baselined) {
+			void this.autoSyncScan();
+		}
+	}
+
+	stopAutoSync(): void {
+		if (this.autoSyncTimer !== null) {
+			window.clearInterval(this.autoSyncTimer);
+			this.autoSyncTimer = null;
+		}
+	}
+
+	async resetAutoSyncBaseline(): Promise<void> {
+		this.settings.auto_sync_baselined = false;
+		this.settings.auto_sync_seen = [];
+		await this.settings.save();
+		new Notice("Scrybble: auto-sync baseline reset. Your current library is the new starting point.");
+		this.startAutoSync();
+	}
+
+	async syncEntireLibrary(): Promise<void> {
+		if (!this.authentication.isAuthenticated()) {
+			new Notice("Scrybble: sign in before syncing your library.");
+			return;
+		}
+		new Notice("Scrybble: scanning your reMarkable library...");
+		const files: { path: string; id: string }[] = [];
+		await this.collectRemarkableFiles("/", new Set<string>(), files);
+
+		const seen = new Set(this.settings.auto_sync_seen);
+		let queued = 0;
+		for (const f of files) {
+			if (f.path in this.settings.sync_state) {
+				continue;
+			}
+			seen.add(f.path);
+			this.syncQueue.requestSync(f.id, f.path);
+			queued += 1;
+		}
+		this.settings.auto_sync_seen = Array.from(seen);
+		this.settings.auto_sync_baselined = true;
+		await this.settings.save();
+		new Notice(`Scrybble: queued ${queued} file(s) for sync.`);
+	}
+
+	private async autoSyncScan(): Promise<void> {
+		if (!this.settings.self_hosted || !this.settings.auto_sync || !this.authentication.isAuthenticated()) {
+			return;
+		}
+		try {
+			const files: { path: string; id: string }[] = [];
+			await this.collectRemarkableFiles("/", new Set<string>(), files);
+
+			if (!this.settings.auto_sync_baselined) {
+				const seen = new Set(this.settings.auto_sync_seen);
+				for (const f of files) {
+					seen.add(f.path);
+				}
+				this.settings.auto_sync_seen = Array.from(seen);
+				const delta = await this.fetchSyncDelta();
+				for (const d of delta) {
+					if (!(d.filename in this.settings.sync_state)) {
+						this.settings.sync_state[d.filename] = d.id;
+					}
+				}
+				this.settings.auto_sync_baselined = true;
+				await this.settings.save();
+				return;
+			}
+
+			await this.sync();
+
+			const seen = new Set(this.settings.auto_sync_seen);
+			let requested = 0;
+			for (const f of files) {
+				if (requested >= AUTO_SYNC_MAX_PER_TICK) {
+					break;
+				}
+				if (seen.has(f.path) || f.path in this.settings.sync_state) {
+					continue;
+				}
+				seen.add(f.path);
+				this.syncQueue.requestSync(f.id, f.path);
+				requested += 1;
+			}
+			if (requested > 0) {
+				this.settings.auto_sync_seen = Array.from(seen);
+				await this.settings.save();
+			}
+		} catch (e) {
+			pino.error(e, "Automatic sync scan failed");
+		}
+	}
+
+	private async collectRemarkableFiles(path: string, visited: Set<string>, acc: { path: string; id: string }[]): Promise<void> {
+		if (visited.has(path)) {
+			return;
+		}
+		visited.add(path);
+
+		let tree: RMFileTree;
+		try {
+			tree = await this.fetchFileTree(path);
+		} catch (e) {
+			pino.error(e, `Automatic sync could not list "${path}"`);
+			return;
+		}
+
+		for (const item of tree.items) {
+			if (item.type === "d") {
+				await this.collectRemarkableFiles(item.path, visited, acc);
+			} else if (item.type === "f" && item.id) {
+				acc.push({ path: item.path, id: item.id });
+			}
 		}
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -213,7 +213,7 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 		});
 	}
 
-	async sync() {
+	async sync(auto: boolean = false) {
 		const latestSyncState = await this.fetchSyncDelta()
 		const settings = this.settings
 
@@ -224,7 +224,7 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 			const file_not_synced_locally = !(filename in settings.sync_state);
 			const file_has_update = settings.sync_state[filename] < id;
 			if (file_not_synced_locally || file_has_update) {
-				await this.syncQueue.downloadProcessedFile(filename, download_url, id)
+				await this.syncQueue.downloadProcessedFile(filename, download_url, id, auto)
 			}
 		}
 	}
@@ -487,6 +487,9 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 	}
 
 	async resetAutoSyncBaseline(): Promise<void> {
+		if (!this.settings.self_hosted) {
+			return;
+		}
 		this.settings.auto_sync_baselined = false;
 		this.settings.auto_sync_seen = [];
 		await this.settings.save();
@@ -495,6 +498,9 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 	}
 
 	async syncEntireLibrary(): Promise<void> {
+		if (!this.settings.self_hosted) {
+			return;
+		}
 		if (!this.authentication.isAuthenticated()) {
 			new Notice("Scrybble: sign in before syncing your library.");
 			return;
@@ -510,7 +516,7 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 				continue;
 			}
 			seen.add(f.path);
-			this.syncQueue.requestSync(f.id, f.path);
+			this.syncQueue.requestSync(f.id, f.path, true);
 			queued += 1;
 		}
 		this.settings.auto_sync_seen = Array.from(seen);
@@ -544,7 +550,7 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 				return;
 			}
 
-			await this.sync();
+			await this.sync(true);
 
 			const seen = new Set(this.settings.auto_sync_seen);
 			let requested = 0;
@@ -556,7 +562,7 @@ export default class Scrybble extends Plugin implements ScrybbleApi, ScrybblePer
 					continue;
 				}
 				seen.add(f.path);
-				this.syncQueue.requestSync(f.id, f.path);
+				this.syncQueue.requestSync(f.id, f.path, true);
 				requested += 1;
 			}
 			if (requested > 0) {

--- a/src/SettingsImpl.ts
+++ b/src/SettingsImpl.ts
@@ -10,6 +10,11 @@ export class SettingsImpl implements ScrybbleSettings {
 	}
 	public readonly sync_state: Record<string, number>  = {}
 
+	public readonly auto_sync: boolean = false;
+	public readonly auto_sync_interval_minutes: number = 15;
+	public readonly auto_sync_baselined: boolean = false;
+	public readonly auto_sync_seen: string[] = [];
+
 	public readonly refresh_token?: string;
 	public readonly access_token?: string;
 	public readonly save: () => Promise<void>;
@@ -18,6 +23,10 @@ export class SettingsImpl implements ScrybbleSettings {
 		this.sync_folder = s?.sync_folder ?? "scrybble/";
 		this.sync_state = s?.sync_state ?? {};
 		this.self_hosted = s?.self_hosted ?? false;
+		this.auto_sync = s?.auto_sync ?? false;
+		this.auto_sync_interval_minutes = s?.auto_sync_interval_minutes ?? 15;
+		this.auto_sync_baselined = s?.auto_sync_baselined ?? false;
+		this.auto_sync_seen = s?.auto_sync_seen ?? [];
 		if (s?.custom_host) {
 			this.custom_host = s.custom_host;
 		}

--- a/src/SyncJob.ts
+++ b/src/SyncJob.ts
@@ -47,7 +47,8 @@ export class SyncJob extends StateMachine<SyncJobStates, SyncJobEvents> {
 		init: SyncJobStates.init = SyncJobStates.init,
 		private onStateChange: (filename: string, newState: SyncJobStates, job: SyncJob) => void,
 		public filename: string,
-		public rmFileId?: string
+		public rmFileId?: string,
+		public auto: boolean = false
 	) {
 		super(init, [], console);
 

--- a/src/SyncQueue.ts
+++ b/src/SyncQueue.ts
@@ -8,7 +8,7 @@ import path from "path";
 import {pino} from "./errorHandling/logging";
 
 export interface ISyncQueue {
-	requestSync(rmFileId: string, name: string): void;
+	requestSync(rmFileId: string, name: string, auto?: boolean): void;
 
 	subscribeToSyncStateChangesForFile(path: string, callback: (newState: SyncJobStates, job: SyncJob) => void): void;
 
@@ -72,17 +72,17 @@ export class SyncQueue implements ISyncQueue {
 		this.syncJobStateChangeListeners.delete(path);
 	}
 
-	async downloadProcessedFile(filename: string, download_url: string, sync_id: number) {
+	async downloadProcessedFile(filename: string, download_url: string, sync_id: number, auto: boolean = false) {
 		pino.info(`Creating sync job for file '${filename}' from the sync delta`)
-		const syncJob = new SyncJob(0, SyncJobStates.init, this.syncjobStateChangeListener.bind(this), filename);
+		const syncJob = new SyncJob(0, SyncJobStates.init, this.syncjobStateChangeListener.bind(this), filename, undefined, auto);
 		pino.info(`Sync job for file '${filename}' from sync delta is successfully created, will now be queued`)
 		await syncJob.readyToDownload(download_url, sync_id)
 		this.syncJobs.push(syncJob)
 	}
 
-	requestSync(rmFileId: string, name: string) {
+	requestSync(rmFileId: string, name: string, auto: boolean = false) {
 		pino.info(`Creating sync job for file '${name}' (id: ${rmFileId}) requested by the user`)
-		const job = new SyncJob(0, SyncJobStates.init, this.syncjobStateChangeListener.bind(this), name, rmFileId)
+		const job = new SyncJob(0, SyncJobStates.init, this.syncjobStateChangeListener.bind(this), name, rmFileId, auto)
 		pino.info(`Sync job for file '${name}' requested by the user is successfully created, will now be queued`)
 		this.syncJobs.push(job)
 	}
@@ -103,6 +103,20 @@ export class SyncQueue implements ISyncQueue {
 		}
 	}
 
+	private hasNoHandwriting(unzippedFiles: Record<string, Uint8Array>): boolean {
+		const meta = Object.keys(unzippedFiles).find(filename => /_scrybble\.json$/.test(filename));
+		if (!meta) {
+			// No sidecar (older renderer): can't tell, so don't skip.
+			return false;
+		}
+		try {
+			const parsed = JSON.parse(new TextDecoder().decode(unzippedFiles[meta]));
+			return parsed.annotation_pages === 0;
+		} catch {
+			return false;
+		}
+	}
+
 	private async writeDownloadedZip(job: SyncJob, file: ArrayBuffer) {
 		let relativePath = dirPath(job.filename)
 		let nameOfFile = sanitizeFilename(basename(job.filename))
@@ -120,7 +134,14 @@ export class SyncQueue implements ISyncQueue {
 					else resolve(unzipped);
 				});
 			});
-			
+
+			if (job.auto && this.settings.self_hosted && this.hasNoHandwriting(unzippedFiles)) {
+				pino.info(`Auto-sync: skipping '${job.filename}', no handwriting`)
+				await job.downloaded()
+				this.onFinishedDownloadFile(job, true)
+				return
+			}
+
 			await this.extractFileFromZip(this.vault, unzippedFiles, /_remarks(-only)?.pdf/, `${out_path}.pdf`)
 			await this.extractFileFromZip(this.vault, unzippedFiles, /_obsidian.md/, `${out_path}.md`, false)
 			await job.downloaded()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,14 @@ export class Settings extends PluginSettingTab {
 	private connectedMessage: HTMLElement;
 	// @ts-expect-error TS2564
 	private clientIdSetting: Setting;
+	// @ts-expect-error TS2564
+	private autoSyncSetting: Setting;
+	// @ts-expect-error TS2564
+	private autoSyncIntervalSetting: Setting;
+	// @ts-expect-error TS2564
+	private resetBaselineSetting: Setting;
+	// @ts-expect-error TS2564
+	private syncEverythingSetting: Setting;
 
 	constructor(app: App, private readonly plugin: Scrybble) {
 		super(app, plugin);
@@ -45,6 +53,7 @@ Default is "scrybble/"`)
 						this.plugin.settings.self_hosted = value;
 						await this.plugin.settings.save();
 						this.updateVisibility();
+						this.plugin.startAutoSync();
 					})
 			})
 
@@ -88,6 +97,44 @@ Default is "scrybble/"`)
 		this.connectedMessage = containerEl.createEl("p", {
 			text: "Connected to the official scrybble server, no additional configuration required."
 		});
+
+		this.autoSyncSetting = new Setting(containerEl)
+			.setName("Automatic sync")
+			.setDesc("Self-hosted only: periodically pull new reMarkable files into your vault automatically.")
+			.addToggle((toggle) => toggle
+				.setValue(this.plugin.settings.auto_sync)
+				.onChange(async (value) => {
+					this.plugin.settings.auto_sync = value;
+					await this.plugin.settings.save();
+					this.plugin.startAutoSync();
+				}));
+
+		this.autoSyncIntervalSetting = new Setting(containerEl)
+			.setName("Automatic sync interval (minutes)")
+			.setDesc("How often to check for new files. Minimum 1.")
+			.addText((text) => text
+				.setValue(String(this.plugin.settings.auto_sync_interval_minutes))
+				.onChange(async (value) => {
+					const n = parseInt(value, 10);
+					this.plugin.settings.auto_sync_interval_minutes = Number.isFinite(n) && n >= 1 ? n : 15;
+					await this.plugin.settings.save();
+					this.plugin.startAutoSync();
+				}));
+
+		this.resetBaselineSetting = new Setting(containerEl)
+			.setName("Reset auto-sync baseline")
+			.setDesc("Forget what auto-sync has seen and re-snapshot your current library as the new starting point. Downloads nothing.")
+			.addButton((btn) => btn
+				.setButtonText("Reset baseline")
+				.onClick(() => this.plugin.resetAutoSyncBaseline()));
+
+		this.syncEverythingSetting = new Setting(containerEl)
+			.setName("Sync entire library")
+			.setDesc("Pull every reMarkable file into your vault now (one-time backfill). This can be a lot of files.")
+			.addButton((btn) => btn
+				.setButtonText("Sync everything")
+				.setWarning()
+				.onClick(() => this.plugin.syncEntireLibrary()));
 
 		this.updateVisibility();
 	}
@@ -139,12 +186,20 @@ Default is "scrybble/"`)
 			this.clientSecretSetting.settingEl.style.display = "";
 			this.clientIdSetting.settingEl.style.display = "";
 			this.connectedMessage.style.display = "none";
+			this.autoSyncSetting.settingEl.style.display = "";
+			this.autoSyncIntervalSetting.settingEl.style.display = "";
+			this.resetBaselineSetting.settingEl.style.display = "";
+			this.syncEverythingSetting.settingEl.style.display = "";
 			this.updateClientFieldsVisibility();
 		} else {
 			this.endpointSetting.settingEl.style.display = "none";
 			this.clientSecretSetting.settingEl.style.display = "none";
 			this.clientIdSetting.settingEl.style.display = "none";
 			this.connectedMessage.style.display = "";
+			this.autoSyncSetting.settingEl.style.display = "none";
+			this.autoSyncIntervalSetting.settingEl.style.display = "none";
+			this.resetBaselineSetting.settingEl.style.display = "none";
+			this.syncEverythingSetting.settingEl.style.display = "none";
 		}
 	}
 }


### PR DESCRIPTION
Draft for discussion. Adds an **opt-in, self-hosted-only** background sync so new reMarkable files land in the vault automatically, without the per-file cost that makes this impractical for the paid service.

### How it works
Reuses the existing engine (no new download logic): `SyncQueue` + `sync()`/`fetchSyncDelta`. Adds a periodic scan (default 15 min) that:
1. runs `sync()` to download anything newly processed/updated in the delta, then
2. walks the file tree and `requestSync`s files that are new, **capped at 10 per tick**.

### Doesn't touch the backlog
On first enable it **baselines** the current library (records every path as seen + seeds `sync_state` from the current delta) and downloads nothing. Only files that appear *after* enabling are synced, so a months-old untouched library is left alone.

### Controls (Settings, shown only when Self-hosted)
- **Automatic sync** toggle (default off) + interval.
- **Reset baseline** — re-snapshot the current library as the new starting point; downloads nothing.
- **Sync entire library** — one-shot full backfill when you actually want everything (SyncQueue throttles to 3 concurrent).

Gated to `self_hosted` in both the settings UI and at runtime.

### Two things to decide / know
1. **Gating is your product call.** It's self-hosted-only here; happy to expose it for paid hosting if you want.
2. **Limitation:** `RMTreeItem` has no timestamp/version, so "recently modified" isn't expressible client-side — the scan detects *new* files, and edits to existing files only flow in if the backend reprocesses them (delta id bumps). A clean long-term version would want a `files-modified-since` endpoint on the backend; flagging as a follow-up.

### Verification
`bun run build` passes (tsc + esbuild). The cucumber suite doesn't run in my environment (pre-existing `ERR_REQUIRE_ESM` in the ts-node harness, unrelated to this change). Manual testing against a self-hosted stack recommended before un-drafting.