### PR TITLE
Sync: show the failure reason to the user when a sync errors

### DIFF
--- a/@types/scrybble.ts
+++ b/@types/scrybble.ts
@@ -111,6 +111,7 @@ type SyncStateSuccess  = {
 type SyncStateError = {
 	error: true;
 	completed: false;
+	error_message?: string | null;
 }
 
 export type SyncStateResponse = {

--- a/src/SyncJob.ts
+++ b/src/SyncJob.ts
@@ -1,4 +1,5 @@
 import {StateMachine, t} from "typescript-fsm";
+import {Notice} from "obsidian";
 import {SyncProgressNotice} from "./ui/Components/SyncNotice";
 
 export enum SyncJobStates {
@@ -143,7 +144,10 @@ export class SyncJob extends StateMachine<SyncJobStates, SyncJobEvents> {
 		await this.dispatch(SyncJobEvents.downloadRequestSent)
 	}
 
-	async processingFailed() {
+	async processingFailed(errorMessage?: string | null) {
+		if (errorMessage) {
+			new Notice(`Scrybble couldn't sync "${this.filename}": ${errorMessage}`, 10000);
+		}
 		await this.dispatch(SyncJobEvents.failedToProcess);
 	}
 

--- a/src/SyncQueue.ts
+++ b/src/SyncQueue.ts
@@ -206,7 +206,7 @@ export class SyncQueue implements ISyncQueue {
 		if (state.completed) {
 			await job.readyToDownload(state.download_url, state.id)
 		} else if (state.error) {
-			await job.processingFailed()
+			await job.processingFailed(state.error_message)
 		} else {
 			await job.fileStillProcessing()
 		}


### PR DESCRIPTION
## Why

When a sync fails server-side (e.g. a document can't be downloaded), the plugin only learned that it failed — the actual reason was logged in `sync_logs` on the server and never shown. The user just saw a silent failure / nothing to download.

## Change

The sync status response now includes an `error_message` (the latest server-side error for that sync — added in scrybble-site, see Scrybbling-together/scrybble-site#35). This PR consumes it:

- `SyncStateError` gains `error_message?: string | null`.
- `checkProcessingState` passes `state.error_message` into `processingFailed()`.
- `processingFailed()` shows it in a `Notice`: *Scrybble couldn't sync "<file>": <reason>*.

So a failed sync now explains itself — e.g. *"Failed downloading file, it doesn't seem to exist (try resyncing on your device)"* — instead of failing silently.

## Notes

- Backend counterpart: Scrybbling-together/scrybble-site#35 (also adds a path-based download fallback so many of these failures now succeed outright; this PR covers the cases that genuinely can't be recovered).
- Typechecks clean (`tsc -noEmit -skipLibCheck`). The existing `SyncProgressNotice` still shows the failed state; this adds the human-readable reason alongside it.